### PR TITLE
修复点击状态栏无法关闭actionsheet，以及横屏弹出actionsheet的布局问题

### DIFF
--- a/Source/TBActionSheet/TBActionSheet.m
+++ b/Source/TBActionSheet/TBActionSheet.m
@@ -256,10 +256,11 @@ typedef void (^TBBlurEffectBlock)(void);
     actionSheetVC.actionSheet = self;
     
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    self.window.windowLevel = UIWindowLevelStatusBar + 100;
     self.window.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.window.opaque = NO;
-    self.window.rootViewController = actionSheetVC;
     [self.window makeKeyAndVisible];
+    self.window.rootViewController = actionSheetVC;
 }
 
 /**


### PR DESCRIPTION
![0d9cf0bd-86bf-4028-827b-109447621491](https://cloud.githubusercontent.com/assets/1835487/26441693/1c609fb4-4164-11e7-96fd-16e4bb4f79d7.png)
调整window的level，让它处于window的最上层，就不会被statusbar挡住了。参考：https://github.com/facebook/FBMemoryProfiler/blob/master/FBMemoryProfiler/Window/FBMemoryProfilerWindow.m#L24

![simulator screen shot 25 may 2017 3 59 46 pm](https://cloud.githubusercontent.com/assets/1835487/26441852/c37117f2-4164-11e7-804e-d1585b186ab9.png)
横屏弹出sheet时，TBActionSheetController的supportedInterfaceOrientations访问self.actionSheet.supportedInterfaceOrientations值，但是此时appearance上的supportedInterfaceOrientations属性还没有赋值给TBActionSheet的supportedInterfaceOrientations属性，所以需要在访问appearance属性之前，调用[self.window makeKeyAndVisible];